### PR TITLE
Remove GAZEBO profile from superbuild

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -62,7 +62,6 @@ RUN git clone https://github.com/robotology/robotology-superbuild.git --depth 1 
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
           -DYCM_EP_INSTALL_DIR=${ROBOTOLOGY_SUPERBUILD_INSTALL_DIR} \
           -DROBOTOLOGY_ENABLE_CORE:BOOL=ON \
-          -DROBOTOLOGY_USES_GAZEBO:BOOL=ON \
           -DROBOTOLOGY_ENABLE_DYNAMICS:BOOL=ON \
           -DROBOTOLOGY_ENABLE_ROBOT_TESTING:BOOL=ON && make
 


### PR DESCRIPTION
This PR proposes to get rid of the GAZEBO profile while building the docker.

Put on hold as we'd need first to check that the red-ball-demo test works as intended.